### PR TITLE
egrep -> grep -E

### DIFF
--- a/za-rust-atclone-handler
+++ b/za-rust-atclone-handler
@@ -87,7 +87,7 @@ if (( ${+ICE[rustup]} )) {
                     --component cargo clippy rustc rust-fmt rust-std \
                     --default-toolchain nightly \
                     --profile minimal \
-                |& command egrep '(installing|installed)'
+                |& command grep -E '(installing|installed)'
             } else {
                 bin/rustup-init \
                     -y \
@@ -108,7 +108,7 @@ if (( ${+ICE[rustup]} )) {
             local -x CARGO_HOME="$dir" RUSTUP_HOME="$dir/rustup" PATH="$dir/bin:$PATH"
             if (( !OPTS[opt_-q,--quiet] )) {
                 print -P -- "%F{38}rust annex: %F{154}Running \`rustup update'...%f"
-                command rustup update |& command egrep -i '(error|warning|installing|info: latest update )'
+                command rustup update |& command grep -E -i '(error|warning|installing|info: latest update )'
             } else {
                 command rustup update &> /dev/null
             }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description <!--- Describe your changes in detail -->

`egrep` is dead, long live `grep -E`

## Motivation and Context <!--- Why is this change required? What problem does it solve? -->

Without this change, this annexe yells

```
egrep: warning: egrep is obsolescent; using grep -E
```

## Related Issue(s) <!--- If it fixes an open issue, please link to the issue here. -->

## Usage examples <!--- Provide examples of intended usage -->

```zsh
zi ice \
    id-as"rust" \
    wait"0" \
    lucid \
    rustup \
    as"command" \
    pick"bin/rustc" \
    atload='export CARGO_HOME=$PWD RUSTUP_HOME=$PWD/rustup'
zi load zdharma-continuum/null
```

## How Has This Been Tested? <!--- Please describe in detail how you tested your changes. -->

See above.

## Types of changes <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist: <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
