### PR TITLE
fix: latest rustup-init requires comma-separated list of component

### DIFF
--- a/za-rust-atclone-handler
+++ b/za-rust-atclone-handler
@@ -84,7 +84,7 @@ if (( ${+ICE[rustup]} )) {
                 bin/rustup-init \
                     -y \
                     --no-modify-path \
-                    --component cargo clippy rustc rust-fmt rust-std \
+                    --component cargo,clippy,rustc,rust-fmt,rust-std \
                     --default-toolchain nightly \
                     --profile minimal \
                 |& command grep -E '(installing|installed)'
@@ -92,7 +92,7 @@ if (( ${+ICE[rustup]} )) {
                 bin/rustup-init \
                     -y \
                     --no-modify-path \
-                    --component cargo clippy rustc rust-fmt rust-std \
+                    --component cargo,clippy,rustc,rust-fmt,rust-std \
                     --default-toolchain nightly \
                     --profile minimal \
                 &> /dev/null


### PR DESCRIPTION
## Description
zinit-annex-rust failed to clone repositories, because the latest rustup-init requires comma-separated list of component since https://github.com/rust-lang/rustup/pull/4076.

```
rustup-init 1.28.1 (bb9441b61 2025-03-05)

The installer for rustup

Usage: rustup-init[EXE] [OPTIONS]

Options:
  -v, --verbose
          Set log level to 'DEBUG' if 'RUSTUP_LOG' is unset
  -q, --quiet
          Disable progress output, set log level to 'WARN' if 'RUSTUP_LOG' is unset
  -y
          Disable confirmation prompt
      --default-host <DEFAULT_HOST>
          Choose a default host triple
      --default-toolchain <DEFAULT_TOOLCHAIN>
          Choose a default toolchain to install. Use 'none' to not install any toolchains at all
      --profile <PROFILE>
          [default: default] [possible values: minimal, default, complete]
  -c, --component <COMPONENT>
          Comma-separated list of component names to also install
  -t, --target <TARGET>
          Comma-separated list of target names to also install
      --no-update-default-toolchain
          Don't update any existing default toolchain after install
      --no-modify-path
          Don't configure the PATH environment variable
  -h, --help
          Print help
  -V, --version
          Print version
```

## Related Issue(s)

<!--- If it fixes an open issue, add a link the issue -->

## Motivation and Context <!--- What problem does it solve? -->

## Usage examples

```zsh
zinit ice rustup cargo'!lsd'
zinit load zdharma-continuum/null
```

## How Has This Been Tested?

## Types of changes <!--- Put an `x` in all the boxes that apply. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change
- [ ] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [ ] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
